### PR TITLE
error correction 'getWindow' of undefined

### DIFF
--- a/insomnia.android.js
+++ b/insomnia.android.js
@@ -1,9 +1,9 @@
-var appModule = require("application");
+var application = require("application");
 
 exports.keepAwake = function () {
   return new Promise(function (resolve, reject) {
     try {
-      var window = appModule.android.currentContext.getWindow();
+      var window = application.android.startActivity.getWindow();
       window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       resolve();
     } catch (ex) {
@@ -16,7 +16,7 @@ exports.keepAwake = function () {
 exports.allowSleepAgain = function () {
   return new Promise(function (resolve, reject) {
     try {
-      var window = appModule.android.currentContext.getWindow();
+      var window = application.android.startActivity.getWindow();
       window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       resolve();
     } catch (ex) {


### PR DESCRIPTION
error correction
Error: Uncaught (in promise): TypeError: Cannot read property 'getWindow' of undefined

All changes were tested on Android 7 and Android 5